### PR TITLE
removes call to luasnip config as it overwrites user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ cursor is within math mode. Alternatively, you can use
 Can be installed like any neovim plugin. If using
 [wbthomason/packer.nvim](https://github.com/wbthomason/packer.nvim):
 
+For autosnippets to work correctly one should enable them in the luasnip config (`require('luasnip').setup({enable_autosnippets = true})`).
+
 ```lua
 use {
   "iurimateus/luasnip-latex-snippets.nvim",

--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -14,8 +14,6 @@ local default_opts = {
 M.setup = function(opts)
   opts = vim.tbl_deep_extend("force", default_opts, opts or {})
 
-  ls.config.setup({ enable_autosnippets = true })
-
   local augroup = vim.api.nvim_create_augroup("luasnip-latex-snippets", {})
   vim.api.nvim_create_autocmd("FileType", {
     pattern = "tex",


### PR DESCRIPTION
Calling the luasnip setup function in the plugins init overwrites settings made by the user. 