### PR TITLE
Fixes typo with the "ali" trigger which creates an "align" environment

### DIFF
--- a/lua/luasnip-latex-snippets/bwA.lua
+++ b/lua/luasnip-latex-snippets/bwA.lua
@@ -6,7 +6,7 @@ local i = ls.insert_node
 local bwA = {
   s(
     { trig = "ali", name = "Align" },
-    { t({ "\\begin{align*}", "\t" }), i(1), t({ "", ".\\end{align*}" }) }
+    { t({ "\\begin{align*}", "\t" }), i(1), t({ "", "\\end{align*}" }) }
   ),
 
   ls.parser.parse_snippet(


### PR DESCRIPTION
Removes the period before the \end{align*}