### PR TITLE
Add more snippets

### DIFF
--- a/lua/luasnip-latex-snippets/math_iA.lua
+++ b/lua/luasnip-latex-snippets/math_iA.lua
@@ -18,7 +18,7 @@ function M.retrieve(is_math)
   return {
     s(
       {
-        trig = "(%a)bar",
+        trig = "(%a+)bar",
         wordTrig = false,
         regTrig = true,
         name = "bar",
@@ -30,6 +30,31 @@ function M.retrieve(is_math)
     ),
     s(
       {
+        trig = "(%a+)und",
+        wordTrig = false,
+        regTrig = true,
+        name = "underline",
+        priority = 100,
+      },
+      f(function(_, snip)
+        return string.format("\\underline{%s}", snip.captures[1])
+      end, {})
+    ),
+    s(
+      {
+        trig = "(%a)dot",
+        wordTrig = false,
+        regTrig = true,
+        name = "dot",
+        priority = 100,
+      },
+      f(function(_, snip)
+        return string.format("\\dot{%s}", snip.captures[1])
+      end, {})
+    ),
+
+    s(
+      {
         trig = "(%a+)hat",
         wordTrig = false,
         regTrig = true,
@@ -38,6 +63,30 @@ function M.retrieve(is_math)
       },
       f(function(_, snip)
         return string.format("\\hat{%s}", snip.captures[1])
+      end, {})
+    ),
+    s(
+      {
+        trig = "(%a+)ora",
+        wordTrig = false,
+        regTrig = true,
+        name = "ora",
+        priority = 100,
+      },
+      f(function(_, snip)
+        return string.format("\\overrightarrow{%s}", snip.captures[1])
+      end, {})
+    ),
+    s(
+      {
+        trig = "(%a+)ola",
+        wordTrig = false,
+        regTrig = true,
+        name = "ola",
+        priority = 100,
+      },
+      f(function(_, snip)
+        return string.format("\\overleftarrow{%s}", snip.captures[1])
       end, {})
     ),
 
@@ -66,6 +115,7 @@ function M.retrieve(is_math)
     parse_snippet({ trig = "...", name = "ldots", priority = 100 }, "\\ldots "),
     parse_snippet({ trig = "!>", name = "mapsto" }, "\\mapsto "),
     parse_snippet({ trig = "iff", name = "iff" }, "\\iff"),
+    parse_snippet({ trig = "siff", name = "short iff", priority = 100}, "\\Leftrightarrow"),
     parse_snippet({ trig = "ooo", name = "\\infty" }, "\\infty"),
     parse_snippet({ trig = "rij", name = "mrij" }, "(${1:x}_${2:n})_{${3:$2}\\in${4:\\N}}$0"),
     parse_snippet({ trig = "nabl", name = "nabla" }, "\\nabla "),
@@ -75,6 +125,7 @@ function M.retrieve(is_math)
     parse_snippet({ trig = "//", name = "Fraction" }, "\\frac{$1}{$2}$0"),
     parse_snippet({ trig = "\\\\\\", name = "setminus" }, "\\setminus"),
     parse_snippet({ trig = "->", name = "to", priority = 100 }, "\\to "),
+    parse_snippet({ trig = "-->", name = "long to", priority = 200 }, "\\longrightarrow "),
 
     parse_snippet({ trig = "letw", name = "let omega" }, "Let $\\Omega \\subset \\C$ be open."),
     parse_snippet({ trig = "nnn", name = "bigcap" }, "\\bigcap_{${1:i \\in ${2: I}}} $0"),
@@ -120,6 +171,7 @@ function M.retrieve(is_math)
     parse_snippet({ trig = "compl", name = "complement" }, "^{c}"),
     parse_snippet({ trig = "__", name = "subscript" }, "_{$1}$0"),
     parse_snippet({ trig = "=>", name = "implies" }, "\\implies"),
+    parse_snippet({ trig = "simp", name = "short implies" }, "\\Rightarrow"),
     parse_snippet({ trig = "=<", name = "implied by" }, "\\impliedby"),
     parse_snippet({ trig = "<<", name = "<<" }, "\\ll"),
 


### PR DESCRIPTION
First of all thanks for the great work! There are some itches to be scratched with that PR

## Changed

- `aabar` will produce $\overline{aa}$. Previously it generated $a\overline{a}$

## New

- inserting `zaund` will produce $\underline{za}$
- inserting `qdot` will produce $\dot{q}$
- inserting `ABora` will produce $\overrightarrow{AB}$
- inserting `BAola` will produce $\overleftarrow{BA}$
- inserting `siff`(**s**hort **iff**) will produce $\Leftrightarrow$
- inserting `-->` will produce $\longrightarrow$
- inserting `simp`(**s**hort **imp**lies) will produce $\Rightarrow$
