### PR TITLE
Improve markdown support.

### DIFF
--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -94,8 +94,8 @@ end
 M.setup_markdown = function()
   local ls = require("luasnip")
 
-  local is_math = utils.is_math_md()
-  local not_math = utils.not_math_md()
+  local is_math = utils.is_math_md
+  local not_math = utils.not_math_md
 
   local autosnippets = _autosnippets(is_math, not_math)
   local trigger_of_snip = function(s)
@@ -132,4 +132,5 @@ M.setup_markdown = function()
   })
 end
 
+M.is_math_md = utils.is_math_md
 return M

--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -136,4 +136,12 @@ M.setup_markdown = function()
     default_priority = 0,
   })
 end
+
+M.inspect_node = function(lang)
+  local node = require("luasnip-latex-snippets.util.ts_utils").get_node_at_cursor(lang)
+  while node do
+    print(node:type())
+    node = node:parent()
+  end
+end
 return M

--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -1,6 +1,6 @@
 local utils = require("luasnip-latex-snippets.util.utils")
 local pipe = utils.pipe
-local no_backslash = utils.no_backslash
+-- local no_backslash = utils.no_backslash
 
 local M = {}
 
@@ -18,8 +18,12 @@ M.setup = function(opts)
     group = augroup,
     once = true,
     callback = function()
-      local is_math = utils.with_opts(utils.is_math, opts.use_treesitter)
-      local not_math = utils.with_opts(utils.not_math, opts.use_treesitter)
+      local function_opts = {
+        lang = "tex",
+        use_treesitter = opts.use_treesitter,
+      }
+      local is_math = utils.with_opts(utils.is_math, function_opts)
+      local not_math = utils.with_opts(utils.not_math, function_opts)
       M.setup_tex(is_math, not_math)
     end,
   })
@@ -94,8 +98,9 @@ end
 M.setup_markdown = function()
   local ls = require("luasnip")
 
-  local is_math = utils.is_math_md
-  local not_math = utils.not_math_md
+  local function_opts = { lang = "markdown" }
+  local is_math = utils.with_opts(utils.is_math, function_opts)
+  local not_math = utils.with_opts(utils.not_math, function_opts)
 
   local autosnippets = _autosnippets(is_math, not_math)
   local trigger_of_snip = function(s)
@@ -131,6 +136,4 @@ M.setup_markdown = function()
     default_priority = 0,
   })
 end
-
-M.is_math_md = utils.is_math_md
 return M

--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -94,8 +94,8 @@ end
 M.setup_markdown = function()
   local ls = require("luasnip")
 
-  local is_math = utils.with_opts(utils.is_math, true)
-  local not_math = utils.with_opts(utils.not_math, true)
+  local is_math = utils.is_math_md()
+  local not_math = utils.not_math_md()
 
   local autosnippets = _autosnippets(is_math, not_math)
   local trigger_of_snip = function(s)

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -65,4 +65,16 @@ function M.in_mathzone()
   return false
 end
 
+function M.in_mathzone_md()
+  local nt_utils = require("nvim-treesitter.ts_utils")
+  local node = nt_utils.get_node_at_cursor()
+  while node do
+    if node:type() == "latex_block" then
+      return true
+    end
+    node = node:parent()
+  end
+  return false
+end
+
 return M

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -67,7 +67,7 @@ function M.in_mathzone_md()
   local node = M.get_node_at_cursor("markdown_inline")
   while node do
     if node:type() == "latex_block" then
-      return false
+      return true
     end
     node = node:parent()
   end

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -12,8 +12,25 @@ local TEXT_NODES = {
   label_reference = true,
 }
 
-function M.in_text(check_parent)
-  local node = vim.treesitter.get_node({ lang = "latex" })
+function M.get_node_at_cursor(lang)
+  local bufnr = vim.api.nvim_get_current_buf()
+  local pos = vim.api.nvim_win_get_cursor(0)
+  local row, col = pos[1] - 1, pos[2]
+
+  assert(row >= 0 and col >= 0, "Invalid position: row and col must be non-negative")
+
+  local ts_range = { row, col, row, col }
+
+  local root_lang_tree = vim.treesitter.get_parser(bufnr, lang)
+  if not root_lang_tree then
+    return
+  end
+
+  return root_lang_tree:named_node_for_range(ts_range)
+end
+
+function M.in_text_tex(check_parent)
+  local node = M.get_node_at_cursor("latex")
   while node do
     if node:type() == "text_mode" then
       if check_parent then
@@ -33,13 +50,24 @@ function M.in_text(check_parent)
   return true
 end
 
-function M.in_mathzone()
-  local node = vim.treesitter.get_node({ lang = "latex" })
+function M.in_mathzone_tex()
+  local node = M.get_node_at_cursor("latex")
   while node do
     if TEXT_NODES[node:type()] then
       return false
     elseif MATH_NODES[node:type()] then
       return true
+    end
+    node = node:parent()
+  end
+  return false
+end
+
+function M.in_mathzone_md()
+  local node = M.get_node_at_cursor("markdown_inline")
+  while node do
+    if node:type() == "latex_block" then
+      return false
     end
     node = node:parent()
   end

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -12,27 +12,8 @@ local TEXT_NODES = {
   label_reference = true,
 }
 
-local function get_node_at_cursor()
-  local pos = vim.api.nvim_win_get_cursor(0)
-  -- Subtract one to account for 1-based row indexing in nvim_win_get_cursor
-  local row, col = pos[1] - 1, pos[2]
-
-  local parser = vim.treesitter.get_parser(0, "latex")
-  if not parser then
-    return
-  end
-
-  local root_tree = parser:parse({ row, col, row, col })[1]
-  local root = root_tree and root_tree:root()
-  if not root then
-    return
-  end
-
-  return root:named_descendant_for_range(row, col, row, col)
-end
-
 function M.in_text(check_parent)
-  local node = get_node_at_cursor()
+  local node = vim.treesitter.get_node({ lang = "latex" })
   while node do
     if node:type() == "text_mode" then
       if check_parent then
@@ -53,23 +34,11 @@ function M.in_text(check_parent)
 end
 
 function M.in_mathzone()
-  local node = get_node_at_cursor()
+  local node = vim.treesitter.get_node({ lang = "latex" })
   while node do
     if TEXT_NODES[node:type()] then
       return false
     elseif MATH_NODES[node:type()] then
-      return true
-    end
-    node = node:parent()
-  end
-  return false
-end
-
-function M.in_mathzone_md()
-  local nt_utils = require("nvim-treesitter.ts_utils")
-  local node = nt_utils.get_node_at_cursor()
-  while node do
-    if node:type() == "latex_block" then
       return true
     end
     node = node:parent()

--- a/lua/luasnip-latex-snippets/util/utils.lua
+++ b/lua/luasnip-latex-snippets/util/utils.lua
@@ -35,7 +35,7 @@ M.is_math = function(opts)
 
   local lang = opts.lang
 
-  assert(lang == nil or lang == "", "lang must be specified")
+  assert(lang ~= nil and lang ~= "", "lang must be specified: " .. lang)
 
   if lang == "tex" then
     local use_treesitter = opts.use_treesitter or false
@@ -56,7 +56,7 @@ M.not_math = function(opts)
 
   local lang = opts.lang
 
-  assert(lang == nil or lang == "", "lang must be specified")
+  assert(lang ~= nil and lang ~= "", "lang must be specified: " .. lang)
 
   if lang == "tex" then
     local use_treesitter = opts.use_treesitter or false
@@ -64,7 +64,7 @@ M.not_math = function(opts)
       return ts_utils.in_text_tex(true)
     end
 
-    return not M.is_math()
+    return not M.is_math(opts)
   elseif lang == "markdown" then
     return not ts_utils.in_mathzone_md()
   else

--- a/lua/luasnip-latex-snippets/util/utils.lua
+++ b/lua/luasnip-latex-snippets/util/utils.lua
@@ -47,7 +47,14 @@ M.not_math = function(treesitter)
 end
 
 M.is_math_md = function()
-  return ts_utils.in_mathzone_md()
+  local node = vim.treesitter.get_node({ lang = "markdown_inline" })
+  while node do
+    if node:type() == "latex_block" then
+      return true
+    end
+    node = node:parent()
+  end
+  return false
 end
 
 M.not_math_md = function()

--- a/lua/luasnip-latex-snippets/util/utils.lua
+++ b/lua/luasnip-latex-snippets/util/utils.lua
@@ -46,6 +46,14 @@ M.not_math = function(treesitter)
   return not M.is_math()
 end
 
+M.is_math_md = function()
+  return ts_utils.in_mathzone_md()
+end
+
+M.not_math_md = function()
+  return not M.is_math_md()
+end
+
 M.comment = function()
   return vim.fn["vimtex#syntax#in_comment"]() == 1
 end

--- a/lua/luasnip-latex-snippets/util/utils.lua
+++ b/lua/luasnip-latex-snippets/util/utils.lua
@@ -25,40 +25,51 @@ M.pipe = function(fns)
   end
 end
 
-M.no_backslash = function(line_to_cursor, matched_trigger)
+M.no_backslash = function(line_to_cursor)
   return not line_to_cursor:find("\\%a+$", -#line_to_cursor)
 end
 
 local ts_utils = require("luasnip-latex-snippets.util.ts_utils")
-M.is_math = function(treesitter)
-  if treesitter then
-    return ts_utils.in_mathzone()
-  end
+M.is_math = function(opts)
+  opts = opts or {}
 
-  return vim.fn["vimtex#syntax#in_mathzone"]() == 1
-end
+  local lang = opts.lang
 
-M.not_math = function(treesitter)
-  if treesitter then
-    return ts_utils.in_text(true)
-  end
+  assert(lang == nil or lang == "", "lang must be specified")
 
-  return not M.is_math()
-end
-
-M.is_math_md = function()
-  local node = vim.treesitter.get_node({ lang = "markdown_inline" })
-  while node do
-    if node:type() == "latex_block" then
-      return true
+  if lang == "tex" then
+    local use_treesitter = opts.use_treesitter or false
+    if use_treesitter then
+      return ts_utils.in_mathzone_tex()
     end
-    node = node:parent()
+
+    return vim.fn["vimtex#syntax#in_mathzone"]() == 1
+  elseif lang == "markdown" then
+    return ts_utils.in_mathzone_md()
+  else
+    assert(true, "file type not support: " .. lang)
   end
-  return false
 end
 
-M.not_math_md = function()
-  return not M.is_math_md()
+M.not_math = function(opts)
+  opts = opts or {}
+
+  local lang = opts.lang
+
+  assert(lang == nil or lang == "", "lang must be specified")
+
+  if lang == "tex" then
+    local use_treesitter = opts.use_treesitter or false
+    if use_treesitter then
+      return ts_utils.in_text_tex(true)
+    end
+
+    return not M.is_math()
+  elseif lang == "markdown" then
+    return not ts_utils.in_mathzone_md()
+  else
+    assert(true, "file type not support: " .. lang)
+  end
 end
 
 M.comment = function()


### PR DESCRIPTION
Improve markdown support use `markdown_inline` treesitter.
It was tested to run well after nvim 0.9.0, and it should be run well in older version too.