### PR TITLE
fix: don't hang on unbalanced parentheses expression

### DIFF
--- a/lua/luasnip-latex-snippets/math_wrA.lua
+++ b/lua/luasnip-latex-snippets/math_wrA.lua
@@ -22,7 +22,7 @@ local frac_node = {
 
     i = #stripped
     local depth = 0
-    while true do
+    while i >= 0 do
       if stripped:sub(i, i) == ")" then
         depth = depth + 1
       end
@@ -35,10 +35,11 @@ local frac_node = {
       i = i - 1
     end
 
-    local rv =
-      string.format("%s\\frac{%s}", stripped:sub(1, i - 1), stripped:sub(i + 1, #stripped - 1))
-
-    return rv
+    if depth ~= 0 then
+      return string.format("%s\\frac{}", stripped)
+    else
+      return string.format("%s\\frac{%s}", stripped:sub(1, i - 1), stripped:sub(i + 1, #stripped - 1))
+    end
   end, {}),
   t("{"),
   i(1),


### PR DESCRIPTION
Hello,

Trying to create a fraction from like that `+3)/` will cause neovim to hang. This is due to while loop never stopping in case we got unbalanced expression
<https://github.com/iurimateus/luasnip-latex-snippets.nvim/blob/337c597e03e45b9ba78f016651fbfd599ebc7537/lua/luasnip-latex-snippets/math_wrA.lua#L25-L36>

Adding simple bound check is not enough, because in the edge case we would still return weird string, so instead we return empty fraction.

In short:
Before PR: `+3)/` -> *neovim hangs*
After PR: `+3)/` -> `+3)\frac{}{}`
