### PR TITLE
Treesitter polling instead of parsing on each snippet trigger

### DIFF
--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -4,13 +4,14 @@ local no_backslash = utils.no_backslash
 
 local M = {}
 
-local default_opts = {
+local opts = {
   use_treesitter = false,
   allow_on_markdown = true,
 }
 
-M.setup = function(opts)
-  opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+M.setup = function(override_opts)
+  override_opts = override_opts or {}
+  opts = vim.tbl_deep_extend("force", opts, override_opts)
 
   local augroup = vim.api.nvim_create_augroup("luasnip-latex-snippets", {})
   vim.api.nvim_create_autocmd("FileType", {

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -22,7 +22,7 @@ local function get_node_at_cursor()
     return
   end
 
-  local root_tree = parser:parse({ row, col, row, col })[1]
+  local root_tree = parser:parse()[1]
   local root = root_tree and root_tree:root()
   if not root then
     return

--- a/lua/luasnip-latex-snippets/util/ts_utils.lua
+++ b/lua/luasnip-latex-snippets/util/ts_utils.lua
@@ -1,4 +1,4 @@
-local M = {}
+local M = { polling = {} }
 
 local MATH_NODES = {
   displayed_equation = true,
@@ -64,5 +64,134 @@ function M.in_mathzone()
   end
   return false
 end
+
+--- @alias node_stack string[]
+--- @class tracked_buffer
+--- @field timer uv_timer_t
+--- @field parser LanguageTree
+--- @field tree TSTree
+--- @field node_stack node_stack
+--- @field in_math boolean
+--- @field in_text boolean
+--- @type table<buffer, tracked_buffer>
+local tracked_bufs = {}
+
+local function get_node()
+  local row, col = unpack(vim.api.nvim_win_get_cursor(0))
+  row = row - 1
+  col = col - 1
+  local buf = vim.api.nvim_get_current_buf()
+  local root_node = tracked_bufs[buf].tree:root()
+  return root_node:named_descendant_for_range(row, col, row, col)
+end
+
+--- @return node_stack ns A list of types of nodes. The first element is the type of deepest node.
+local function get_node_stack()
+  local node = get_node()
+  local stack = {}
+  while node do
+    table.insert(stack, node:type())
+    node = node:parent()
+  end
+  return stack
+end
+
+--- @param node_stack node_stack
+--- @return boolean
+--- Check for a given node stack whether we are in math
+local function stack_is_in_math(node_stack)
+  for _, node_type in ipairs(node_stack) do
+    if TEXT_NODES[node_type] then
+      return false
+    end
+    if MATH_NODES[node_type] then
+      return true
+    end
+  end
+  return false
+end
+
+--- @param node_stack node_stack
+--- @param check_parent boolean
+--- @return boolean
+--- Check for a given node stack whether we are in text
+local function stack_is_in_text(node_stack, check_parent)
+  for _, node_type in ipairs(node_stack) do
+    if TEXT_NODES[node_type] and not check_parent then
+      return true
+    end
+    if MATH_NODES[node_type] then
+      return false
+    end
+  end
+  return true
+end
+
+--- @param buf buffer buffer handle
+--- Create a callback function which will track whether user is currently
+--- editing math
+--- @return function
+local function mk_callback(buf)
+  return function()
+    local current_buf = vim.api.nvim_get_current_buf()
+    if buf ~= current_buf then
+      return
+    end
+
+    local parser = tracked_bufs[buf].parser
+    tracked_bufs[buf].tree = parser:parse()[1]
+    local node_stack = get_node_stack()
+    tracked_bufs[buf].node_stack = node_stack
+    tracked_bufs[buf].in_math = stack_is_in_math(node_stack)
+    tracked_bufs[buf].in_text = stack_is_in_text(node_stack, true)
+  end
+end
+
+--- @param buf buffer Buffer handle
+--- Start tracking a buffer.
+--- Assert that given buffer was not tracked before.
+local function init_buf(buf)
+  assert(not tracked_bufs[buf], "Attempt to initialize already tracked buffer")
+  local success, parser = pcall(vim.treesitter.get_parser, buf, "latex")
+  if not success then
+    vim.notify("Could not load latex treesitter parser. Is it installed?\n TSInstall latex", vim.log.levels.ERROR)
+    error(parser, 2)
+  end
+  local timer = vim.loop.new_timer()
+  timer:start(0, 100, vim.schedule_wrap(mk_callback(buf)))
+
+  tracked_bufs[buf] = {
+    timer = timer,
+    parser = parser,
+    tree = nil,
+    node_stack = {},
+    in_math = false,
+    in_text = true,
+  }
+end
+
+--- @param buf buffer Buffer handle
+--- Stop tracking a buffer.
+--- Assert that given buffer was tracked before.
+local function deinit_buf(buf)
+  assert(tracked_bufs[buf], "Attempt to deinitialize buffer that is not tracked")
+  tracked_bufs[buf].timer:stop()
+  tracked_bufs[buf].timer:close()
+  tracked_bufs[buf].parser:destroy()
+  tracked_bufs[buf] = nil
+end
+
+--- @param buf buffer
+--- @return boolean b Whether buffer is tracked by the plugin
+local function is_buf_tracked(buf)
+  return tracked_bufs[buf] ~= nil
+end
+
+M.polling = {
+  init_buf = init_buf,
+  deinit_buf = deinit_buf,
+  is_buf_tracked = is_buf_tracked,
+  tracked_bufs = tracked_bufs,
+}
 
 return M


### PR DESCRIPTION
## Motivation

While attending lectures(only math) and taking notes in markdown starts OK.
<br>*Note: I always start with an empty markdown file.*<br>
Neovim does not feel slow, everything expands in time and general experience is
good.

Then, closer to the middle of a lecture(~100 lines of markdown written) some snippets stop expanding, expanding
takes a good amount of time, at some point it becomes unbearable.

Strangely, executing `:e` helps but not for long, soon enough problem repeats
and at some point, if the lecture is long enough, neovim is slow even after that
procedure.

I am sure that this is mostly due to snippets because without them neovim is
responsive when editing markdown for a long time. My skills in profiling lack so
It was decided to first write a polling mechanism, and only then benchmark.

## Benchmarking

Two benchmarks were done: with and without polling

To benchmark I used [luajit's profiler](https://luajit.org/ext_profiler.html)
(which tbh doesn't say much), a minimal neovim configuration and two tests:

1. enter a big enough markdown file, go to the very end, then type mk and hold
   down letter c, which will start expanding to many `\subset`'s
2. Having a shell script, use dotool to enter a piece of markdown in the same
   file as above

### Prerequisites

Minimal configuration used:

<details>
<summary>init.lua</summary>

```lua
local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
if not vim.loop.fs_stat(lazypath) then
  vim.fn.system({
    "git",
    "clone",
    "--filter=blob:none",
    "https://github.com/folke/lazy.nvim.git",
    "--branch=stable", -- latest stable release
    lazypath,
  })
end
vim.opt.rtp:prepend(lazypath)

vim.opt.wrap = true
vim.opt.textwidth = 80

vim.loader.enable()

local plugins = {}
local function use(plugin)
  table.insert(plugins, plugin)
end

use({
  -- "iurimateus/luasnip-latex-snippets.nvim",
  dir = "~/Projects/nvim/luasnip-latex-snippets.nvim",
  dependencies = { "L3MON4D3/LuaSnip", "nvim-treesitter/nvim-treesitter" },
  config = function()
    require("luasnip-latex-snippets").setup({
      use_treesitter = true,
      markdown_use_polling = false, -- TOGGLE THAT WHEN BENCHMARKING
    })
    local ls = require("luasnip")
    ls.config.setup({ enable_autosnippets = true })
    vim.keymap.set({ "i", "s" }, "<Tab>", function() ls.jump(1) end, { silent = true })
    vim.keymap.set({ "i", "s" }, "<S-Tab>", function() ls.jump(-1) end, { silent = true })
  end,
})

use({
  "nvim-treesitter/nvim-treesitter",
  build = ":TSUpdate",
  config = function()
    local ts_conf = require("nvim-treesitter.configs")

    ts_conf.setup({
      ensure_installed = { "markdown", "markdown_inline", "latex" },
      highlight = { enable = true },
    })
  end,
})

require("lazy").setup(plugins, {
  performance = {
    cache = { enabled = false },
  },
})

local p = require "jit.p"
vim.api.nvim_create_autocmd("ExitPre", {
  callback = function()
    p.stop()
  end,
})
p.start("-3vFm3", "profiler.log")

```

</details>

Here is the file which was tested on(1000 lines):

[test.md](https://github.com/iurimateus/luasnip-latex-snippets.nvim/files/14282839/test.md)

Please note that in the given `dotool-###.sh` files there are options that set
the keyboard layout. To execute them correctly you must set yours otherwise it
will produce gibberish(and it is actually dangerous because you don't know what
will it type)

See [dotool documentation](https://git.sr.ht/~geb/dotool/tree/master/doc/dotool.1.scd)

### Holding the C

It shows how fast luasnip reacts with either polling or no polling.
To measure that, just count how many there are letters `c` vs how many there
are `\subset`'s

<details>
<summary>dotool-c.sh</summary>

```bash
#!/usr/bin/env sh
export DOTOOL_XKB_LAYOUT="pl"
export DOTOOL_XKB_VARIANT="dvp"

pgrep dotoold || {
dotoold &
sleep 3
}

dotoolc <<EOF
typedelay 20
type nvim ./test.md -u ../init.lua
key enter
EOF

sleep 3

dotoolc <<EOF
key G zt o enter
type mk
EOF

sleep 1

dotoolc <<EOF
keydown c
EOF

sleep 5 && dotoolc <<EOF
keyup c
EOF

dotoolc <<EOF
key esc
type :x
key enter
EOF
```

</details>

- `test-polling.md` is result after running `dotool-c.sh` with polling enabling,
  and `profiler-polling.md` is profiler stats for that run
- `test-no-polling.md` is result after running `dotool-c.sh` with polling
  disabled, and `profiler-no-polling.md` is profiler stats for that run

As you can see with polling it did much better in terms how many `cc`'s were
expanded.

### Typing in a snippet

There is a file which types a snippet(*works only on Linux*, obviously read before
execution):

<details>
<summary>dotool-snip.sh</summary>

```bash
#!/usr/bin/env sh
export DOTOOL_XKB_LAYOUT="pl"
export DOTOOL_XKB_VARIANT="dvp"

pgrep dotoold || {
dotoold &
sleep 3
}

dotoolc <<EOF
typedelay 20
type nvim ./test.md -u ../init.lua
key enter
EOF

sleep 3

dotoolc <<EOF
typedelay 70
keydelay 100
key j j j ctrl+f ctrl+f ctrl+f
EOF

type_some_text() {
dotoolc <<EOF
key esc G zt o enter

type ## Markdown and limit
key enter enter
type What *could* be **better** than some \`markdown\` and mkttmath?
key enter enter

type - limit mkg for a
key enter
type - function with domain
key enter
type - mkA ccRR.
key enter
type - at any mkx_0 innA.

key enter enter

type dm
key backspace
type AAepsilon > 0\;
key enter
type EEdelta > 0\;
key enter
type AAx innA\;
key enter
type |x - x_0| < 0 => |f(x) - g| < epsilon
key esc
EOF
}
type_some_text

dotoolc <<EOF
key esc
type :x
key enter
EOF
```

</details>

Typing robotically a snippet of markdown with latex is assumed to show something
in profiler results,... doesn't tell much though

## On PR

Inspired by <https://github.com/iurimateus/luasnip-latex-snippets.nvim/pull/11>

Libuv's timer has a delay of 100, which might be a bit too frequent. I believe
setting it to 200 or even 300 wouldn't hurt although I didn't try.

There was no field-testing as i have a pause in studies, so I actually don't
know how it behaves when editing markdown for a prolonged time.

Also if it behaves well, I would drop support for non-cached version of functions.

Q: why use polling instead of triggering updates on every keypress?

A:
> Note: To use the parser directly inside a |nvim_buf_attach()| Lua
callback, you must call |vim.treesitter.get_parser()| before you register
your callback. But preferably parsing shouldn't be done directly in the
change callback anyway as they will be very frequent. Rather a plugin that
does any kind of analysis on a tree should use a timer to throttle too
frequent updates.

(from <https://neovim.io/doc/user/treesitter.html#lua-treesitter-languagetree>)

This is a draft, and I am open to any suggestions.

Archive with the results: 
[ls-latex-snips-benchmark.zip](https://github.com/iurimateus/luasnip-latex-snippets.nvim/files/14283237/ls-latex-snips-benchmark.zip)
