### PR TITLE
Fix cases environment presence

### DIFF
--- a/lua/luasnip-latex-snippets/bwA.lua
+++ b/lua/luasnip-latex-snippets/bwA.lua
@@ -26,7 +26,6 @@ function M.retrieve(not_math)
     ),
 
     parse_snippet({ trig = "beg", name = "begin{} / end{}" }, "\\begin{$1}\n\t$0\n\\end{$1}"),
-    parse_snippet({ trig = "case", name = "cases" }, "\\begin{cases}\n\t$1\n\\end{cases}"),
 
     s({ trig = "bigfun", name = "Big function" }, {
       t({ "\\begin{align*}", "\t" }),

--- a/lua/luasnip-latex-snippets/math_iA_no_backslash.lua
+++ b/lua/luasnip-latex-snippets/math_iA_no_backslash.lua
@@ -17,6 +17,7 @@ function M.retrieve(is_math)
 
   return {
     parse_snippet({ trig = "sq", name = "\\sqrt{}" }, "\\sqrt{${1:${TM_SELECTED_TEXT}}} $0"),
+    parse_snippet({ trig = "case", name = "cases" }, "\\begin{cases}\n\t$1\n\\end{cases}"),
 
     with_priority({ trig = "hat", name = "hat" }, "\\hat{$1}$0 "),
     with_priority({ trig = "bar", name = "bar" }, "\\overline{$1}$0 "),


### PR DESCRIPTION
According to the amsmath documentation, cases enviornment should be present enclosed within a math envirionment.
Fix its recoginition to be made under math environment.