### PR TITLE
feat!(wA): remove full stops in block math snippet (`dm`)

### DIFF
--- a/lua/luasnip-latex-snippets/init.lua
+++ b/lua/luasnip-latex-snippets/init.lua
@@ -124,7 +124,7 @@ M.setup_markdown = function()
   -- tex delimiters
   local normal_wA_tex = {
     parse_snippet({ trig = "mk", name = "Math" }, "$${1:${TM_SELECTED_TEXT}}$"),
-    parse_snippet({ trig = "dm", name = "Block Math" }, "$$\n\t${1:${TM_SELECTED_TEXT}}\n.$$"),
+    parse_snippet({ trig = "dm", name = "Block Math" }, "$$\n\t${1:${TM_SELECTED_TEXT}}\n$$"),
   }
   vim.list_extend(filtered, normal_wA_tex)
 

--- a/lua/luasnip-latex-snippets/math_i.lua
+++ b/lua/luasnip-latex-snippets/math_i.lua
@@ -33,7 +33,7 @@ function M.retrieve(is_math)
     ),
     parse_snippet(
       { trig = "ddx", name = "d/dx" },
-      "\\frac{\\mathrm{d/${1:V}}}{\\mathrm{d${2:x}}} $0"
+      "\\frac{\\mathrm{d${1:V}}}{\\mathrm{d${2:x}}} $0"
     ),
 
     parse_snippet({ trig = "pmat", name = "pmat" }, "\\begin{pmatrix} $1 \\end{pmatrix} $0"),

--- a/lua/luasnip-latex-snippets/wA.lua
+++ b/lua/luasnip-latex-snippets/wA.lua
@@ -11,7 +11,7 @@ function M.retrieve(not_math)
 
   return {
     parse_snippet({ trig = "mk", name = "Math" }, "\\( ${1:${TM_SELECTED_TEXT}} \\)$0"),
-    parse_snippet({ trig = "dm", name = "Block Math" }, "\\[\n\t${1:${TM_SELECTED_TEXT}}\n.\\] $0"),
+    parse_snippet({ trig = "dm", name = "Block Math" }, "\\[\n\t${1:${TM_SELECTED_TEXT}}\n\\] $0"),
   }
 end
 


### PR DESCRIPTION
In addition to the random slash, there are full stops in the block math snippets which do not seem to have any purpose.  If I want to add full stops, it is easy to just type them in.